### PR TITLE
Fix invalid example smart-configuration json

### DIFF
--- a/spec/conformance/index.md
+++ b/spec/conformance/index.md
@@ -234,8 +234,8 @@ Content-Type: application/json
   "registration_endpoint": "https://ehr.example.com/auth/register",
   "scopes_supported": ["openid", "profile", "launch", "launch/patient", "patient/*.*", "user/*.*", "offline_access"],
   "response_types_supported": ["code", "code id_token", "id_token", "refresh_token"],
-  "management_endpoint": "https://ehr.example.com/user/manage"
-  "introspection_endpoint": "https://ehr.example.com/user/introspect"
+  "management_endpoint": "https://ehr.example.com/user/manage",
+  "introspection_endpoint": "https://ehr.example.com/user/introspect",
   "revocation_endpoint": "https://ehr.example.com/user/revoke",
   "capabilities": ["launch-ehr", "client-public", "client-confidential-symmetric", "context-ehr-patient", "sso-openid-connect"]
 }


### PR DESCRIPTION
The [example smart-configuration response](http://www.hl7.org/fhir/smart-app-launch/conformance/#sample-response) is invalid json due to some missing commas.