### PR TITLE
Correct URL for /.well-known/smart-configuration

### DIFF
--- a/fsh/ig-data/input/pages/index.md
+++ b/fsh/ig-data/input/pages/index.md
@@ -193,7 +193,7 @@ A launch might cause the browser to navigate to:
     Location: https://app/launch?iss=https%3A%2F%2Fehr%2Ffhir&launch=xyz123
 
 On receiving the launch notification, the app would query the issuer's `/metadata/` endpoint or
-[.well-known/smart-configuration.json] endpoint which contains (among other details) the EHR's identifying the OAuth `authorize` and `token`
+[.well-known/smart-configuration] endpoint which contains (among other details) the EHR's identifying the OAuth `authorize` and `token`
 endpoint URLs for use in requesting authorization to access FHIR
 resources.
 
@@ -215,7 +215,7 @@ will launch from its registered URL without a launch id.
 In order to obtain launch context and request authorization to access FHIR
 resources, the app discovers the EHR authorization server's OAuth
 `authorize` and `token` endpoint URLs by querying their
-[.well-known/smart-configuration.json] file.
+[.well-known/smart-configuration] file.
 
 The app then can declare its launch context requirements
 by adding specific scopes to the request it sends to the EHR's authorization
@@ -794,4 +794,4 @@ refresh_token=a47txjiipgxkvohibvsm
 
 [See full payload example](example-request-refresh.html).
 
-[.well-known/smart-configuration.json]: conformance.html#using-well-known
+[.well-known/smart-configuration]: conformance.html#using-well-known


### PR DESCRIPTION
This just remove unnecessary and (AFAICT) incorrect references to `/.well-known/smart-configuration.json`.