### PR TITLE
add parameter to fix jira-link

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -39,6 +39,9 @@ pages:
     title: Conformance
   best-practices.md:
     title: Best Practices
+parameters:
+  path-history: http://hl7.org/fhir/smart-app-launch/history.html
+  jira-code: smart
 
 # ╭────────────────────────────────────────────menu.xml────────────────────────────────────────────╮
 # │  To use a provided ig-data/input/includes/menu.xml file, delete the "menu" property below.     │


### PR DESCRIPTION
~~~json
parameters:
  path-history: http://hl7.org/fhir/smart-app-launch/history.html
  jira-code: smart
~~~

see https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/jira.20error.20with.20package.20name.20change for explanation of` jira-code`

`path-history` was attempt to fix history link in publisher box but it does not do that. see doco here:https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters

