### PR TITLE
Add pre-login session to examples

### DIFF
--- a/input/pages/app-launch.md
+++ b/input/pages/app-launch.md
@@ -112,6 +112,15 @@ for example:
 #### Considerations for PKCE Support
 All SMART apps SHALL support Proof Key for Code Exchange (PKCE).  PKCE is a standardized, cross-platform technique for clients to mitigate the threat of authorization code interception or injection. PKCE is described in [IETF RFC 7636](https://tools.ietf.org/html/rfc7636). SMART servers SHALL support the `S256` `code_challenge_method` and SHALL NOT support the `plain` method.
 
+The app SHALL store the PKCE `code_verifier` on the end-user's device before navigating to the authorize endpoint, and later retrieve it at the app's `redirect_uri`. Storing the verifier on a centralized server defeats the purpose of PKCE.
+
+Established storage methods (such as those discussed in the Openid Connect [Nonce Implementation Notes](https://openid.net/specs/openid-connect-core-1_0.html#NonceNotes)) include:
+1. An encrypted HttpOnly cookie (for web-server based clients)
+2. HTML5 local or session storage ([Web Storage API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API))
+3. Storing in the browser's memory using [Web Workers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) or [JavaScript closures](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures#emulating_private_methods_with_closures)
+
+Web-server based clients that use options 2 or 3 SHOULD consider generating the `code_verifier` from their server and encrypting it before storing in the browser.
+
 #### Related reading
 
 Implementers can review the [OAuth Security Topics](https://tools.ietf.org/html/draft-ietf-oauth-security-topics-16) guidance from IETF as a collection of Best Current Practices.

--- a/input/pages/app-launch.md
+++ b/input/pages/app-launch.md
@@ -109,17 +109,26 @@ for example:
 - App is an HTML5 or JS in-browser app (including single-page applications) that would expose the secret in user space
 - App is a native app that can only distribute a secret statically
 
+#### Validating the state parameter
+All SMART apps SHALL validate the state for any request sent to its redirect URL. This is to combat Cross-Site Request Forgery (CSRF) attacks as outlined in [RFC6819 section 4.4.1.8](https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.1.8).
+
+In general, validating the state requires:
+1. Generating a `state_verifier`:`state` and pair
+2. Storing the `state_verifier` in a pre-login session
+3. Presenting the `state` in the authorization request
+4. At the app's redirect URL, check the presented `state` against the `state_verifier` in the user's pre-login session
+
+<a id="state-verifier-guidance"></a>
+
+##### State Verifier
+For guidance on generating, storing and validating the `state` and `state_verifier`, see the [Openid Connect Core specification](https://openid.net/specs/openid-connect-core-1_0.html#NonceNotes). In that discussion, _cryptographically random value_ is analogous to the `state_verifier` and `nonce` is analagous to `state`.
+
+Note that `state_verifier` is not an explicit parameter in the SMART App Launch. The app is the only entity that ever uses this value and is not expected to present it to the authorization server.
+
 #### Considerations for PKCE Support
 All SMART apps SHALL support Proof Key for Code Exchange (PKCE).  PKCE is a standardized, cross-platform technique for clients to mitigate the threat of authorization code interception or injection. PKCE is described in [IETF RFC 7636](https://tools.ietf.org/html/rfc7636). SMART servers SHALL support the `S256` `code_challenge_method` and SHALL NOT support the `plain` method.
 
-The app SHALL store the PKCE `code_verifier` on the end-user's device before navigating to the authorize endpoint, and later retrieve it at the app's `redirect_uri`. Storing the verifier on a centralized server defeats the purpose of PKCE.
-
-Established storage methods (such as those discussed in the Openid Connect [Nonce Implementation Notes](https://openid.net/specs/openid-connect-core-1_0.html#NonceNotes)) include:
-1. An encrypted HttpOnly cookie (for web-server based clients)
-2. HTML5 local or session storage ([Web Storage API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API))
-3. Storing in the browser's memory using [Web Workers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) or [JavaScript closures](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures#emulating_private_methods_with_closures)
-
-Web-server based clients that use options 2 or 3 SHOULD consider generating the `code_verifier` from their server and encrypting it before storing in the browser.
+For guidance on generating and storing the `code_verifier`, see the guidance on the [state verifier](#state-verifier-guidance) above.
 
 #### Related reading
 

--- a/input/pages/example-app-launch-public.md
+++ b/input/pages/example-app-launch-public.md
@@ -79,6 +79,14 @@ curl -s 'https://smart.argo.run/v/r4/sim/eyJtIjoiMSIsImsiOiIxIiwiaSI6IjEiLCJqIjo
 
 ### Obtain authorization code
 
+The client generates the following:
+- state parameter
+- PKCE code challenge and verifier
+
+To mitigate attacks against the client (such as [CSRF](https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.1.8)), the client saves the `state` and `code_verifier` into a pre-login session, such as in [HTML5 sessionStorage](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#the-sessionstorage-api). The client will retrieve/check these values at its redirect_uri.
+
+Using these parameters, the client redirects the browser to the `authorize_endpoint` from the discovery response (newlines added for clarity):
+
 Generate a PKCE code challenge and verifier, then redirect browser to the `authorize_endpoint` from the discovery response (newlines added for clarity):
 
     https://smart.argo.run/v/r4/sim/eyJtIjoiMSIsImsiOiIxIiwiaSI6IjEiLCJqIjoiMSIsImIiOiI4N2EzMzlkMC04Y2FlLTQxOGUtODljNy04NjUxZTZhYWIzYzYifQ/auth/authorize?
@@ -86,7 +94,8 @@ Generate a PKCE code challenge and verifier, then redirect browser to the `autho
       client_id=demo_app_whatever&
       scope=launch%2Fpatient%20patient%2FObservation.rs%20patient%2FPatient.rs%20offline_access&
       redirect_uri=https%3A%2F%2Fsharp-lake-word.glitch.me%2Fgraph.html&
-      aud=https%3A%2F%2Fsmart.argo.run%2Fv%2Fr4%2Fsim%2FeyJtIjoiMSIsImsiOiIxIiwiaSI6IjEiLCJqIjoiMSIsImIiOiI4N2EzMzlkMC04Y2FlLTQxOGUtODljNy04NjUxZTZhYWIzYzYifQ%2Ffhir&state=0hJc1S9O4oW54XuY&
+      aud=https%3A%2F%2Fsmart.argo.run%2Fv%2Fr4%2Fsim%2FeyJtIjoiMSIsImsiOiIxIiwiaSI6IjEiLCJqIjoiMSIsImIiOiI4N2EzMzlkMC04Y2FlLTQxOGUtODljNy04NjUxZTZhYWIzYzYifQ%2Ffhir&
+      state=0hJc1S9O4oW54XuY&
       code_challenge=YPXe7B8ghKrj8PsT4L6ltupgI12NQJ5vblB07F4rGaw&
       code_challenge_method=S256
 
@@ -96,6 +105,14 @@ Receive authorization code when EHR redirects the browser back to (newlines adde
     https://sharp-lake-word.glitch.me/graph.html?
       code=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjb250ZXh0Ijp7Im5lZWRfcGF0aWVudF9iYW5uZXIiOnRydWUsInNtYXJ0X3N0eWxlX3VybCI6Imh0dHBzOi8vc21hcnQuYXJnby5ydW4vL3NtYXJ0LXN0eWxlLmpzb24iLCJwYXRpZW50IjoiODdhMzM5ZDAtOGNhZS00MThlLTg5YzctODY1MWU2YWFiM2M2In0sImNsaWVudF9pZCI6ImRlbW9fYXBwX3doYXRldmVyIiwiY29kZV9jaGFsbGVuZ2VfbWV0aG9kIjoiUzI1NiIsImNvZGVfY2hhbGxlbmdlIjoiWVBYZTdCOGdoS3JqOFBzVDRMNmx0dXBnSTEyTlFKNXZibEIwN0Y0ckdhdyIsInNjb3BlIjoibGF1bmNoL3BhdGllbnQgcGF0aWVudC9PYnNlcnZhdGlvbi5ycyBwYXRpZW50L1BhdGllbnQucnMiLCJyZWRpcmVjdF91cmkiOiJodHRwczovL3NoYXJwLWxha2Utd29yZC5nbGl0Y2gubWUvZ3JhcGguaHRtbCIsImlhdCI6MTYzMzUzMjAxNCwiZXhwIjoxNjMzNTMyMzE0fQ.xilM68Bavtr9IpklYG-j96gTxAda9r4Z_boe2zv3A3E&
       state=0hJc1S9O4oW54XuY 
+
+At this point the client should check the `state` stored in it's pre-login session against the one presented in the redirect. If the state does not match then the client should clear the pre-login session and reject the authorization code.
+
+If the authorization had failed, the authorization server will present both the `error` and `state` parameter so that the client can clear the pre-login session (newlines added for clarity):
+
+  https://sharp-lake-word.glitch.me/graph.html
+    error=server_error&
+    error_description=You+entered+an+invalid+user+ID+or+authentication+credential.%0aToo+many+authentication+failures.&state=0hJc1S9O4oW54XuY
 
 <a id="step-5-access-token"></a>
 

--- a/input/pages/example-app-launch-symmetric-auth.md
+++ b/input/pages/example-app-launch-symmetric-auth.md
@@ -82,14 +82,21 @@ curl -s 'https://smart.argo.run/v/r4/sim/eyJtIjoiMSIsImsiOiIxIiwiaSI6IjEiLCJqIjo
 
 ### Obtain authorization code
 
-Generate a PKCE code challenge and verifier, then redirect browser to the `authorize_endpoint` from the discovery response (newlines added for clarity):
+The client generates the following (ideally on its backend, not frontend):
+- state parameter
+- PKCE code challenge and verifier
+
+To mitigate attacks against the client (such as [CSRF](https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.1.8)), the client saves the `state` and `code_verifier` into a pre-login session, such as a session cookie. The client will retrieve/check these values at its redirect_uri.
+
+Using these parameters, the client redirects the browser to the `authorize_endpoint` from the discovery response (newlines added for clarity):
 
     https://smart.argo.run/v/r4/sim/eyJtIjoiMSIsImsiOiIxIiwiaSI6IjEiLCJqIjoiMSIsImIiOiI4N2EzMzlkMC04Y2FlLTQxOGUtODljNy04NjUxZTZhYWIzYzYifQ/auth/authorize?
       response_type=code&
       client_id=demo_app_whatever&
       scope=launch%2Fpatient%20patient%2FObservation.rs%20patient%2FPatient.rs%20offline_access&
       redirect_uri=https%3A%2F%2Fsharp-lake-word.glitch.me%2Fgraph.html&
-      aud=https%3A%2F%2Fsmart.argo.run%2Fv%2Fr4%2Fsim%2FeyJtIjoiMSIsImsiOiIxIiwiaSI6IjEiLCJqIjoiMSIsImIiOiI4N2EzMzlkMC04Y2FlLTQxOGUtODljNy04NjUxZTZhYWIzYzYifQ%2Ffhir&state=0hJc1S9O4oW54XuY&
+      aud=https%3A%2F%2Fsmart.argo.run%2Fv%2Fr4%2Fsim%2FeyJtIjoiMSIsImsiOiIxIiwiaSI6IjEiLCJqIjoiMSIsImIiOiI4N2EzMzlkMC04Y2FlLTQxOGUtODljNy04NjUxZTZhYWIzYzYifQ%2Ffhir&
+      state=0hJc1S9O4oW54XuY&
       code_challenge=YPXe7B8ghKrj8PsT4L6ltupgI12NQJ5vblB07F4rGaw&
       code_challenge_method=S256
 
@@ -100,15 +107,25 @@ Receive authorization code when EHR redirects the browser back to (newlines adde
       code=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjb250ZXh0Ijp7Im5lZWRfcGF0aWVudF9iYW5uZXIiOnRydWUsInNtYXJ0X3N0eWxlX3VybCI6Imh0dHBzOi8vc21hcnQuYXJnby5ydW4vL3NtYXJ0LXN0eWxlLmpzb24iLCJwYXRpZW50IjoiODdhMzM5ZDAtOGNhZS00MThlLTg5YzctODY1MWU2YWFiM2M2In0sImNsaWVudF9pZCI6ImRlbW9fYXBwX3doYXRldmVyIiwiY29kZV9jaGFsbGVuZ2VfbWV0aG9kIjoiUzI1NiIsImNvZGVfY2hhbGxlbmdlIjoiWVBYZTdCOGdoS3JqOFBzVDRMNmx0dXBnSTEyTlFKNXZibEIwN0Y0ckdhdyIsInNjb3BlIjoibGF1bmNoL3BhdGllbnQgcGF0aWVudC9PYnNlcnZhdGlvbi5ycyBwYXRpZW50L1BhdGllbnQucnMiLCJyZWRpcmVjdF91cmkiOiJodHRwczovL3NoYXJwLWxha2Utd29yZC5nbGl0Y2gubWUvZ3JhcGguaHRtbCIsImlhdCI6MTYzMzUzMjAxNCwiZXhwIjoxNjMzNTMyMzE0fQ.xilM68Bavtr9IpklYG-j96gTxAda9r4Z_boe2zv3A3E&
       state=0hJc1S9O4oW54XuY 
 
+At this point the client should check the `state` stored in it's pre-login session against the one presented in the redirect. If the state does not match then the client should clear the pre-login session and reject the authorization code.
+
+If the authorization had failed, the authorization server will present both the `error` and `state` parameter so that the client can clear the pre-login session (newlines added for clarity):
+
+  https://sharp-lake-word.glitch.me/graph.html
+    error=server_error&
+    error_description=You+entered+an+invalid+user+ID+or+authentication+credential.%0aToo+many+authentication+failures.&state=0hJc1S9O4oW54XuY
+
 <a id="step-5-access-token"></a>
 
 ### Retrieve access token
+
+
 
 Prepare a client authentication header by base64 encoding `demo_app_whatever:secret-key-1234567890`:
 
     Authorization: Basic ZGVtb19hcHBfd2hhdGV2ZXI6c2VjcmV0LWtleS0xMjM0NTY3ODkw
 
-Prepare arguments for POST to token API (newlines added for clarity):
+Prepare arguments for POST to token API. You should retrieve the `code_verifier` from the pre-login session generated above (newlines added for clarity):
 
 ```
 code=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjb250ZXh0Ijp7Im5lZWRfcGF0aWVudF9iYW5uZXIiOnRydWUsInNtYXJ0X3N0eWxlX3VybCI6Imh0dHBzOi8vc21hcnQuYXJnby5ydW4vL3NtYXJ0LXN0eWxlLmpzb24iLCJwYXRpZW50IjoiODdhMzM5ZDAtOGNhZS00MThlLTg5YzctODY1MWU2YWFiM2M2In0sImNsaWVudF9pZCI6ImRlbW9fYXBwX3doYXRldmVyIiwiY29kZV9jaGFsbGVuZ2VfbWV0aG9kIjoiUzI1NiIsImNvZGVfY2hhbGxlbmdlIjoiWVBYZTdCOGdoS3JqOFBzVDRMNmx0dXBnSTEyTlFKNXZibEIwN0Y0ckdhdyIsInNjb3BlIjoibGF1bmNoL3BhdGllbnQgcGF0aWVudC9PYnNlcnZhdGlvbi5ycyBwYXRpZW50L1BhdGllbnQucnMiLCJyZWRpcmVjdF91cmkiOiJodHRwczovL3NoYXJwLWxha2Utd29yZC5nbGl0Y2gubWUvZ3JhcGguaHRtbCIsImlhdCI6MTYzMzUzMjAxNCwiZXhwIjoxNjMzNTMyMzE0fQ.xilM68Bavtr9IpklYG-j96gTxAda9r4Z_boe2zv3A3E&


### PR DESCRIPTION
This PR adds explicit steps to the example launches regarding this [requirement](http://www.hl7.org/fhir/smart-app-launch/app-launch.html#app-protection):
> Apps SHALL generate an unpredictable state parameter for each user session; SHALL include state with all authorization requests; and SHALL validate the state value for any request sent to its redirect URL.
 
In my experience, apps are not following this requirement. I added explicit steps to the 3 example launch flows that phrase this as a "pre-login" session. I advise apps to store both the `state` and `code_verifier` in the session.

I'm wondering if we should add explicit guidance for public apps to use what I call a `state_verifier` for their pre-login session. The OIDC spec has a similar parameter called `nonce`, and they have this [advice](https://openid.net/specs/openid-connect-core-1_0.html#NonceNotes):

> A related method [to bind nonce to a session] applicable to JavaScript Clients is to store the cryptographically random value in HTML5 local storage and use a cryptographic hash of this value.