### PR TITLE
Clarify dual use of `iss` parameter: SMART launch URL vs RFC 9207

### DIFF
--- a/input/pages/app-launch.md
+++ b/input/pages/app-launch.md
@@ -121,7 +121,7 @@ Servers that support purely browser-based apps SHALL enable [Cross-Origin Resour
 
 #### Related reading
 
-Implementers can review the [OAuth Security Topics](https://tools.ietf.org/html/draft-ietf-oauth-security-topics-16) guidance from IETF as a collection of Best Current Practices.
+Implementers can review the [OAuth Security Topics](https://tools.ietf.org/html/draft-ietf-oauth-security-topics-16) guidance from IETF as a collection of Best Current Practices. When supported by the authorization server, clients are encouraged to validate the `iss` parameter in the authorization response as defined in [IETF RFC 9207](https://tools.ietf.org/html/rfc9207) to mitigate authorization server mix-up attacks.
 
 Some resources shared with apps following this IG may be considered [Patient Sensitive](http://hl7.org/fhir/security.html#Patient); implementers should review the Core FHIR Specification's [Security Page](http://hl7.org/fhir/security.html) for additional security and privacy considerations.
 
@@ -253,6 +253,8 @@ The following parameters are included:
 
 Identifies the EHR's FHIR endpoint, which the app can use to obtain
 additional details about the EHR including its authorization URL.
+
+Note: This `iss` parameter applies to the app launch URL, where it conveys the FHIR server base URL. In OAuth 2.0 authorization responses, an `iss` parameter may also be present as defined by [IETF RFC 9207](https://tools.ietf.org/html/rfc9207), where it represents the authorization server issuer. These uses are distinct and occur at different stages of the SMART App Launch flow.
 
       </td>
     </tr>
@@ -523,6 +525,15 @@ risk of leaks.
       <td><span class="label label-success">required</span></td>
       <td>The exact value received from the client.</td>
     </tr>
+    <tr>
+      <td><code>iss</code></td>
+      <td><span class="label label-info">optional</span></td>
+      <td>
+
+The authorization server issuer identifier as defined by [IETF RFC 9207](https://tools.ietf.org/html/rfc9207). If present, this value identifies the authorization server and SHALL NOT be used to determine the FHIR server base URL (which is established during the app launch sequence).
+
+      </td>
+    </tr>
   </tbody>
 </table>
 
@@ -530,6 +541,14 @@ The app SHALL validate the value of the state parameter upon return to the
 redirect URL and SHALL ensure that the state value is securely tied to the
 user’s current session (e.g., by relating the state value to a session
 identifier issued by the app).
+
+If an `iss` parameter is present in the authorization response, it SHALL be
+interpreted as the authorization server issuer identifier as defined by
+[IETF RFC 9207](https://tools.ietf.org/html/rfc9207). Clients MAY validate
+this value against the expected authorization server issuer, for example as
+discovered from the SMART `.well-known/smart-configuration`. Clients SHALL NOT
+use this parameter to determine the FHIR server base URL, which is established
+during the app launch sequence.
 
 ###### *For example*
 

--- a/input/pages/references.md
+++ b/input/pages/references.md
@@ -10,3 +10,4 @@
 * [RFC7521, Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants](https://tools.ietf.org/html/rfc7521)
 * [RFC7523, JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants](https://tools.ietf.org/html/rfc7523)
 * [RFC7591, OAuth 2.0 Dynamic Client Registration Protocol](https://tools.ietf.org/html/rfc7591)
+* [RFC9207, OAuth 2.0 Authorization Server Issuer Identification](https://tools.ietf.org/html/rfc9207)


### PR DESCRIPTION
## Summary

Clarifies the dual use of the `iss` query parameter in SMART App Launch and OAuth 2.0 authorization responses (RFC 9207).

- In SMART launch URLs, `iss` represents the **FHIR server base URL**
- In OAuth authorization responses, `iss` (per RFC 9207) represents the **authorization server issuer**

This PR adds a small clarification to distinguish these contexts and prevent misinterpretation in client implementations.

---

## Problem

SMART App Launch and RFC 9207 both define a query parameter named `iss`, but with different meanings at different stages of the flow:

- **SMART App Launch (launch request)**  
  `iss` = FHIR server base URL

- **RFC 9207 (authorization response)**  
  `iss` = authorization server issuer (to mitigate mix-up attacks)

With increasing adoption of RFC 9207 (e.g. Keycloak ≥23, FAPI 2.0), clients may receive an `iss` parameter on the OAuth callback and incorrectly interpret it as the FHIR server base URL. This can lead to:

- incorrect FHIR endpoint selection
- broken token exchange flows
- workarounds that disable RFC 9207 protections

---

## Proposed Change

This PR introduces minimal, targeted clarifications:

1. **Launch section**  
   Adds a note clarifying that `iss` in the launch URL refers to the FHIR server base URL.

2. **Authorization response handling**  
   Adds normative guidance that:
   - `iss` in the authorization response SHALL be interpreted as the RFC 9207 authorization server issuer  
   - clients MAY validate it against the expected authorization server  
   - clients SHALL NOT use it to determine the FHIR server base URL  

3. **(Optional) Security considerations**  
   Encourages validation of `iss` per RFC 9207 to mitigate mix-up attacks.

---

## Rationale

- The two uses of `iss` occur in **different phases** of the SMART flow (launch vs callback)
- Clarifying this avoids ambiguity without breaking existing behaviour
- Enables safe adoption of RFC 9207 protections rather than encouraging them to be disabled
- Provides clear guidance for client libraries (e.g. smart-on-fhir/client-js)

---

## Backwards Compatibility

This is a **non-breaking clarification** only.  
No changes to existing parameter definitions or behaviour are required.

---

## References

- SMART App Launch specification  
- RFC 9207: OAuth 2.0 Authorization Server Issuer Identification  
- FAPI 2.0 Security Profile (requires RFC 9207 support)

---
## Notes

This PR was prompted by issues observed when RFC 9207 support is enabled (e.g. Keycloak ≥23), where the `iss` parameter in authorization responses was misinterpreted smart-on-fhir/client-js.

Following a [Zulip conversation](https://chat.fhir.org/#narrow/channel/179170-smart/topic/iss.20parameter.20collision.20with.20RFC.209207/with/580506704), this proposal reflects the suggested approach of distinguishing launch vs callback handling (e.g. based on the presence of an authorization `code` parameter), and clarifies the intended meaning of `iss` in each context.

The goal here is simply to make this behaviour explicit for implementers, avoid the need for workarounds (such as disabling RFC 9207), and support safe adoption of its protections.

This is the subject of [FHIR-56141 Disambiguate iss in SMART flows with RFC 9207](https://jira.hl7.org/browse/FHIR-56141).

Very happy for this to be refined, reworked, or redirected to better align with the spec.