### PR TITLE
Consistent Capitalization between examples and spec for token_type

### DIFF
--- a/input/pages/app-launch.md
+++ b/input/pages/app-launch.md
@@ -859,7 +859,7 @@ The response is a JSON object containing a new access token, with the following 
     <tr>
       <td><code>token_type</code></td>
       <td><span class="label label-success">required</span></td>
-      <td>Fixed value: bearer</td>
+      <td>Fixed value: Bearer</td>
     </tr>
     <tr>
       <td><code>expires_in</code></td>

--- a/input/pages/backend-services.md
+++ b/input/pages/backend-services.md
@@ -211,7 +211,7 @@ the following properties:
     <tr>
       <td><code>token_type</code></td>
       <td><span class="label label-success">required</span></td>
-      <td>Fixed value: <code>bearer</code>.</td>
+      <td>Fixed value: <code>Bearer</code>.</td>
     </tr>
     <tr>
       <td><code>expires_in</code></td>


### PR DESCRIPTION
There are two instances where the response in SMART App Launch has the token_type element returned as "Fixed value: bearer", uncapitalized. While this is fine per RFC 6749, the examples in the IG are all "Bearer", so this makes the spec consistent with the examples. (Alternatively, the examples could be updated, but this approach seems preferable). 